### PR TITLE
Adding stop, pause, and resume functions to tags

### DIFF
--- a/ripple.lua
+++ b/ripple.lua
@@ -82,6 +82,24 @@ function Tag:setEffect(name, filter)
 	end
 end
 
+function Tag:stop()
+	for sound, _ in pairs(self._sounds) do
+		sound:stop()
+	end
+end
+
+function Tag:pause()
+	for sound, _ in pairs(self._sounds) do
+		sound:pause()
+	end
+end
+
+function Tag:resume()
+	for sound, _ in pairs(self._sounds) do
+		sound:resume()
+	end
+end
+
 function ripple.newTag()
 	return setmetatable({
 		_volume = 1,


### PR DESCRIPTION
Adding stop, pause, and resume functions to tags. When these functions are called on a tag, it calls the function on all sounds on that tag. An example of where this would be useful would be pausing or stopping music.