### PR TITLE
add update(dt) to tags

### DIFF
--- a/ripple.lua
+++ b/ripple.lua
@@ -251,6 +251,13 @@ function Tag:stop(fadeDuration)
 	end
 end
 
+-- Updates all the sounds and instances tagged with this tag.
+function Tag:update(dt)
+	for child, _ in pairs(self._children) do
+		child:update(dt)
+	end
+end
+
 function ripple.newTag(options)
 	local tag = setmetatable({
 		_effects = {},


### PR DESCRIPTION
A previous pull request (#4) added `stop`, `pause`, and `resume` methods to tags. However, it did not add an `update` method, so while you could pause a tag's children by calling a method on the tag, you could not update it by the same manner. This is primarily relevant when you bring in fading. This pull request aims to resolve that.